### PR TITLE
Fix tab bar label redundancy

### DIFF
--- a/js/appNavigator.js
+++ b/js/appNavigator.js
@@ -19,6 +19,12 @@ const HomeTab = StackNavigator({
   HomeScreen: {
     screen: HomeScreen,
   },
+}, {
+  navigationOptions: {
+    tabBar: {
+      label: 'Home',
+    },
+  },
 });
 
 // The developer tab holding screens in a stack.
@@ -58,6 +64,12 @@ const DeveloperTab = StackNavigator({
   },
   PaymentInfoScreen: {
     screen: PaymentInfoScreen,
+  },
+}, {
+  navigationOptions: {
+    tabBar: {
+      label: 'Developer',
+    },
   },
 });
 

--- a/js/components/developer/choose-job-type-screen/index.js
+++ b/js/components/developer/choose-job-type-screen/index.js
@@ -10,9 +10,6 @@ const JOBS = ['Snöskottning', 'Lövkrattning', 'Städning', 'Ogräsrensning'];
 
 export default class ChooseJobTypeScreen extends Component {
   static navigationOptions = {
-    tabBar: {
-      label: 'Developer',
-    },
     title: 'Choose Job Type',
   };
 

--- a/js/components/developer/create-job-screen/index.js
+++ b/js/components/developer/create-job-screen/index.js
@@ -9,9 +9,6 @@ import CreateJobStyles from './createJobStyles';
 export default class CreateJobScreen extends Component {
 
   static navigationOptions = {
-    tabBar: {
-      label: 'Developer',
-    },
     title: 'Create Job',
   };
 

--- a/js/components/developer/developer-screen/index.js
+++ b/js/components/developer/developer-screen/index.js
@@ -7,9 +7,6 @@ Provides access to components during development.
 */
 export default class DeveloperScreen extends React.Component {
   static navigationOptions = {
-    tabBar: {
-      label: 'Developer',
-    },
     title: 'Developer',
   };
 

--- a/js/components/developer/language-picker-screen/index.js
+++ b/js/components/developer/language-picker-screen/index.js
@@ -8,9 +8,6 @@ export default class LanguagePickerScreen extends Component {
 
   // Navigation information
   static navigationOptions = {
-    tabBar: {
-      label: 'Developer',
-    },
     title: 'Language Picker',
   };
 

--- a/js/components/developer/login-screen/index.js
+++ b/js/components/developer/login-screen/index.js
@@ -14,9 +14,6 @@ const LOGO_URL = 'https://facebook.github.io/react/img/logo_og.png';
 
 export default class LoginScreen extends Component {
   static navigationOptions = {
-    tabBar: {
-      label: 'Developer',
-    },
     title: 'Login',
   };
 

--- a/js/components/developer/modal-card-screen/index.js
+++ b/js/components/developer/modal-card-screen/index.js
@@ -9,9 +9,6 @@ export default class ModalCardScreen extends Component {
 
   // Navigation information
   static navigationOptions = {
-    tabBar: {
-      label: 'Developer',
-    },
     title: 'Card Modal',
   };
 

--- a/js/components/developer/my-profile-screen/index.js
+++ b/js/components/developer/my-profile-screen/index.js
@@ -6,11 +6,9 @@ import MakePaymentScreen from '../make-payment-screen';
 
 export default class MyProfileScreen extends Component {
   static navigationOptions = {
-    tabBar: {
-      label: 'Developer',
-    },
     title: 'My Profile',
   };
+
   render() {
     return (
       <Container>

--- a/js/components/developer/networking-screen/index.js
+++ b/js/components/developer/networking-screen/index.js
@@ -8,9 +8,6 @@ export default class NetworkingScreen extends Component {
 
   // Navigation information
   static navigationOptions = {
-    tabBar: {
-      label: 'Developer',
-    },
     title: 'Networking Screen',
   };
 

--- a/js/components/developer/payment-info-screen/index.js
+++ b/js/components/developer/payment-info-screen/index.js
@@ -8,6 +8,9 @@ const alertMessage2 = 'För Kortet .... .... .... 3232\n';
 
 
 export default class PaymentInfoScreen extends Component {
+  static navigationOptions = {
+    title: 'Payment Information',
+  };
 
   render() {
     return (

--- a/js/components/developer/redux-sample-screen/index.js
+++ b/js/components/developer/redux-sample-screen/index.js
@@ -7,9 +7,6 @@ import { decreaseAge } from '../../../actions/person';
 
 class ReduxSampleScreen extends React.Component {
   static navigationOptions = {
-    tabBar: {
-      label: 'Developer',
-    },
     title: 'Redux Sample Screen',
   };
 

--- a/js/components/developer/sample-screen/index.js
+++ b/js/components/developer/sample-screen/index.js
@@ -4,9 +4,6 @@ import I18n from '../../../../I18n/components/developer/sample-screen/I18n';
 
 export default class SampleScreen extends Component {
   static navigationOptions = {
-    tabBar: {
-      label: I18n.t('dev'),
-    },
     title: I18n.t('screenTitle'),
   };
 

--- a/js/components/developer/search-list-screen/index.js
+++ b/js/components/developer/search-list-screen/index.js
@@ -13,9 +13,6 @@ const FILTER = (dataArray, query) =>
 // Example screen containing a SearchList
 export default class SearchListScreen extends React.Component {
   static navigationOptions = {
-    tabBar: {
-      label: 'Developer',
-    },
     title: 'Search List',
   };
 

--- a/js/components/home/home-screen/index.js
+++ b/js/components/home/home-screen/index.js
@@ -3,9 +3,6 @@ import { Text } from 'react-native';
 
 export default class HomeScreen extends React.Component {
   static navigationOptions = {
-    tabBar: {
-      label: 'Home',
-    },
     title: 'Home',
   };
 


### PR DESCRIPTION
Instead of having each screen redundantly set the label of the tabbed navigation, it can be done once and for all in `appNavigator`. This is because the tab bar labels are always the same, and independent of the screen that is currently being displayed.

**Previously each screen redundantly set the label of the tab, for example like this:**
```javascript
// This is the home screen component in the home tab
static navigationOptions = {
  tabBar: {    
    label: 'Home',    
  },   
  title: 'Home Screen',
};
```

**Now each screen only set the title  of the screen (and not the tab bar label), for example like this:**
```javascript
// This is the home screen component in the home tab
static navigationOptions = {
  title: 'Home Screen',
};
```
**Old `appNavigator`:**
```javascript
// The home tab holding screens in a stack.
const HomeTab = StackNavigator({
  HomeScreen: {
    screen: HomeScreen,
  },
});
```

**Updated `appNavigator` contains navigation options:**
```javascript
// The home tab holding screens in a stack.
const HomeTab = StackNavigator({
  HomeScreen: {
    screen: HomeScreen,
  },
}, {
  navigationOptions: {
    tabBar: {
      label: 'Home',
    },
  },
});
```