### PR TITLE
Replace for-each loop with ListView to display jobs in MyJobsScreen

### DIFF
--- a/js/components/common/list-section-header/listSectionHeader.js
+++ b/js/components/common/list-section-header/listSectionHeader.js
@@ -1,0 +1,16 @@
+import React, { Component } from 'react';
+import { Text, ListItem } from 'native-base';
+
+export default class ListSectionHeader extends Component {
+  static propTypes = {
+    title: React.PropTypes.string.isRequired,
+  }
+
+  render() {
+    return (
+      <ListItem>
+        <Text note>{this.props.title}</Text>
+      </ListItem>
+    );
+  }
+}

--- a/js/components/developer/my-jobs-screen/index.js
+++ b/js/components/developer/my-jobs-screen/index.js
@@ -4,28 +4,23 @@ import MyJobsTab from './myJobsTab';
 import { JOB_STATUS } from '../../common/constants';
 
 // Temporary example data for active jobs.
-const activeJobsData = [
-  { title: 'Pågående uppdrag',
-    jobs: [
-      { title: 'Snöskottning', date: '14 April 20:00', status: JOB_STATUS.ACTIVE },
-      { title: 'Gräsklippning', date: '11 Maj 10:00', status: JOB_STATUS.ACTIVE },
-    ],
-  },
-  { title: 'Ej tilldelade uppdrag',
-    jobs: [
-      { title: 'Snöskottning', date: '2 December 19:00', status: JOB_STATUS.UNASSIGNED },
-    ],
-  },
-];
+const activeJobsData = {
+  'Pågående uppdrag': [
+    { title: 'Snöskottning', date: '14 April 20:00', status: JOB_STATUS.ACTIVE },
+    { title: 'Gräsklippning', date: '11 Maj 10:00', status: JOB_STATUS.ACTIVE },
+  ],
+  'Ej tilldelade uppdrag': [
+    { title: 'Snöskottning', date: '2 December 19:00', status: JOB_STATUS.UNASSIGNED },
+  ],
+};
 
 // Temporary example data for archived jobs.
-const archivedJobsData = [
-  { title: 'Avslutade uppdrag',
-    jobs: [
-      { title: 'Snöskottning', date: '14 Januari 18:00', status: JOB_STATUS.FINISHED },
-    ],
-  },
-];
+const archivedJobsData = {
+  'Avslutade uppdrag': [
+    { title: 'Snöskottning', date: '14 Januari 18:00', status: JOB_STATUS.FINISHED },
+    { title: 'Snöskottning', date: '14 Januari 18:00', status: JOB_STATUS.FINISHED },
+  ],
+};
 
 export default class MyJobsScreen extends Component {
   static navigationOptions = {

--- a/js/components/developer/my-jobs-screen/myJobsTab.js
+++ b/js/components/developer/my-jobs-screen/myJobsTab.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
 import { ListView } from 'react-native';
-import { Container, Text, Content, ListItem } from 'native-base';
+import { Container, Content } from 'native-base';
 import JobListItem from '../../common/job-list-item/jobListItem';
+import ListSectionHeader from '../../common/list-section-header/listSectionHeader';
 import { JOB_STATUS } from '../../common/constants';
 
 export default class MyJobsTab extends Component {
@@ -32,11 +33,7 @@ export default class MyJobsTab extends Component {
 
   renderRow = job => <JobListItem title={job.title} date={job.date} status={job.status} />;
 
-  renderSectionHeader = (sectionData, sectionID) => (
-    <ListItem>
-      <Text note>{sectionID}</Text>
-    </ListItem>
-  );
+  renderSectionHeader = (sectionData, sectionID) => <ListSectionHeader title={sectionID} />;
 
   render() {
     return (

--- a/js/components/developer/my-jobs-screen/myJobsTab.js
+++ b/js/components/developer/my-jobs-screen/myJobsTab.js
@@ -1,47 +1,52 @@
 import React, { Component } from 'react';
+import { ListView } from 'react-native';
 import { Container, Text, Content, ListItem } from 'native-base';
 import JobListItem from '../../common/job-list-item/jobListItem';
 import { JOB_STATUS } from '../../common/constants';
 
 export default class MyJobsTab extends Component {
   static propTypes = {
-    data: React.PropTypes.arrayOf(
-      React.PropTypes.shape({
-        title: React.PropTypes.string,
-        jobs: React.PropTypes.arrayOf(
-          React.PropTypes.shape({
-            title: React.PropTypes.string,
-            date: React.PropTypes.string,
-            status: React.PropTypes.oneOf(Object.values(JOB_STATUS)),
-          })),
-      }),
+    data: React.PropTypes.objectOf(
+      React.PropTypes.arrayOf(
+        React.PropTypes.shape({
+          date: React.PropTypes.string.isRequired,
+          status: React.PropTypes.oneOf(Object.values(JOB_STATUS)),
+          title: React.PropTypes.string.isRequired,
+        }).isRequired,
+      ).isRequired,
     ).isRequired,
   };
 
-  render() {
-    const listItems = [];
-    this.props.data.forEach((jobGroup, i) => {
-      const jobs = [];
-      jobGroup.jobs.forEach((job, j) => {
-        const jobId = `${job.title}-${i}-${j}`;
-        jobs.push(
-          <JobListItem key={jobId} title={job.title} date={job.date} status={job.status} />,
-        );
-      });
+  constructor(props) {
+    super(props);
 
-      const headerId = `${jobGroup.title}-${i}`;
-      listItems.push(
-        <ListItem itemheader key={headerId}>
-          <Text>{jobGroup.title}</Text>
-        </ListItem>
-        , jobs,
-      );
+    const ds = new ListView.DataSource({
+      rowHasChanged: (r1, r2) => r1 !== r2,
+      sectionHeaderHasChanged: (s1, s2) => s1 !== s2,
     });
 
+    this.state = {
+      dataSource: ds.cloneWithRowsAndSections(this.props.data),
+    };
+  }
+
+  renderRow = job => <JobListItem title={job.title} date={job.date} status={job.status} />;
+
+  renderSectionHeader = (sectionData, sectionID) => (
+    <ListItem>
+      <Text note>{sectionID}</Text>
+    </ListItem>
+  );
+
+  render() {
     return (
       <Container>
         <Content>
-          {listItems}
+          <ListView
+            dataSource={this.state.dataSource}
+            renderRow={this.renderRow}
+            renderSectionHeader={this.renderSectionHeader}
+          />
         </Content>
       </Container>
     );


### PR DESCRIPTION
Replaces the for-each loop previously used to display each job in the list, with [the `ListView` component from React Native](https://facebook.github.io/react-native/docs/listview.html), which can show list section headers.

The list section header component has been extracted and moved to the `common` folder.

**The [`ListViewDataSource`](https://facebook.github.io/react-native/docs/listviewdatasource.html#constructor) is built from data of the following form:**
```javascript
{ sectionID_1: [ <rowData1>, <rowData2>, ... ], ... }
```

**For example:**
```javascript
const activeJobsData = {
  'Pågående uppdrag': [
    { title: 'Snöskottning', date: '14 April 20:00', status: JOB_STATUS.ACTIVE },
    { title: 'Gräsklippning', date: '11 Maj 10:00', status: JOB_STATUS.ACTIVE },
  ],
  'Ej tilldelade uppdrag': [
    { title: 'Snöskottning', date: '2 December 19:00', status: JOB_STATUS.UNASSIGNED },
  ],
};
```