### PR TITLE
Change keyboard type of input fields in CreateJobScreen

### DIFF
--- a/js/components/developer/create-job-screen/calendarCard.js
+++ b/js/components/developer/create-job-screen/calendarCard.js
@@ -18,13 +18,13 @@ export default class CalendarCard extends Component {
             <Col>
               <Item floatingLabel>
                 <Label>{DATE_STRING}</Label>
-                <Input />
+                <Input keyboardType="numeric" />
               </Item>
             </Col>
             <Col>
               <Item floatingLabel>
                 <Label>{TIME_STRING}</Label>
-                <Input />
+                <Input keyboardType="numeric" />
               </Item>
             </Col>
           </Grid>

--- a/js/components/developer/create-job-screen/placeCard.js
+++ b/js/components/developer/create-job-screen/placeCard.js
@@ -29,7 +29,7 @@ export default class PlaceCard extends Component {
             <Col>
               <Item floatingLabel>
                 <Label>{ZIP_CODE_STRING}</Label>
-                <Input />
+                <Input keyboardType="numeric" />
               </Item>
             </Col>
           </Grid>


### PR DESCRIPTION
Changes the keyboard type to `numeric`, for input fields for zip code, date, and time, in `CreateJobScreen`.