### PR TITLE
Integrate Redux in React Navigation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,5 +19,17 @@
         ]
       }
     ]
+  },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "extensions": [
+          ".js",
+          ".jsx",
+          ".android.js",
+          ".ios.js"
+        ]
+      }
+    }
   }
 }

--- a/js/actions/navigation.js
+++ b/js/actions/navigation.js
@@ -1,0 +1,9 @@
+export const NAVIGATE = 'NAVIGATE';
+
+export function navigate(routeName, params = {}) {
+  return {
+    type: NAVIGATE,
+    routeName,
+    params,
+  };
+}

--- a/js/app.android.js
+++ b/js/app.android.js
@@ -1,0 +1,67 @@
+import React, { Component } from 'react';
+import { NavigationActions, addNavigationHelpers } from 'react-navigation';
+import { connect } from 'react-redux';
+import { BackAndroid } from 'react-native';
+import AppNavigator from './appNavigator';
+
+/*
+  Main navigation with navigation helpers for Redux.
+  Makes it possible to access navigation state from Redux.
+
+  Android specific (ends with .android.js) to listen to the Android hardware back button.
+*/
+class AppNavigatorWithHelpers extends Component {
+  static propTypes = {
+    dispatch: React.PropTypes.func.isRequired,
+    navigationState: React.PropTypes.shape({
+      index: React.PropTypes.number.isRequired,
+      routes: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
+    }).isRequired,
+  }
+
+  componentDidMount() {
+    BackAndroid.addEventListener('hardwareBackButton', () => {
+      if (this.shouldCloseOnBack()) {
+        return false; // Close application
+      }
+      this.props.dispatch(NavigationActions.back());
+      return true;  // Don't close application
+    });
+  }
+
+  componentWillUnmount() {
+    BackAndroid.removeEventListener('hardwareBackButton');
+  }
+
+  /*
+    Determines if the application should be closed upon hardware back button press.
+    Follows the standard behaviour from react-navigation without Redux integration.
+    Closes the app if the first tab, and the first screen in that tab stack, are selected.
+  */
+  shouldCloseOnBack = () => {
+    const { index, routes } = this.props.navigationState;
+    const tabStack = routes[index];
+    const stackIndex = tabStack.index;
+    return index === 0 && stackIndex === 0;
+  }
+
+  render() {
+    const { dispatch, navigationState } = this.props;
+    return (
+      <AppNavigator
+        navigation={
+          addNavigationHelpers({
+            dispatch,
+            state: navigationState,
+          })
+        }
+      />
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  navigationState: state.navigation,
+});
+
+export default connect(mapStateToProps)(AppNavigatorWithHelpers);

--- a/js/app.ios.js
+++ b/js/app.ios.js
@@ -1,0 +1,41 @@
+import React, { Component } from 'react';
+import { addNavigationHelpers } from 'react-navigation';
+import { connect } from 'react-redux';
+import AppNavigator from './appNavigator';
+
+/*
+  Main navigation with navigation helpers for Redux.
+  Makes it possible to access navigation state from Redux.
+
+  iOS specific (ends with .ios.js), as it does NOT have to listen to a hardware back button.
+  (See app.android.ios for hardware back button listener).
+*/
+class AppNavigatorWithHelpers extends Component {
+  static propTypes = {
+    dispatch: React.PropTypes.func.isRequired,
+    navigationState: React.PropTypes.shape({
+      index: React.PropTypes.number.isRequired,
+      routes: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
+    }).isRequired,
+  }
+
+  render() {
+    const { dispatch, navigationState } = this.props;
+    return (
+      <AppNavigator
+        navigation={
+          addNavigationHelpers({
+            dispatch,
+            state: navigationState,
+          })
+        }
+      />
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  navigationState: state.navigation,
+});
+
+export default connect(mapStateToProps)(AppNavigatorWithHelpers);

--- a/js/app.js
+++ b/js/app.js
@@ -1,7 +1,0 @@
-import React from 'react';
-import AppNavigator from './appNavigator';
-
-const App = () =>
-  <AppNavigator />;
-
-export default App;

--- a/js/reducers/index.js
+++ b/js/reducers/index.js
@@ -4,7 +4,10 @@ import languages from './languages';
 import jobTypes from './jobTypes';
 import ownedJobs from './ownedJobs';
 import creditCards from './creditCards';
+import navigation from './navigation';
 
 const { combineReducers } = require('redux');
 
-export default combineReducers({ person, languages, account, jobTypes, ownedJobs, creditCards });
+export default combineReducers(
+  { navigation, person, languages, account, jobTypes, ownedJobs, creditCards },
+);

--- a/js/reducers/navigation.js
+++ b/js/reducers/navigation.js
@@ -1,0 +1,14 @@
+import { NavigationActions } from 'react-navigation';
+import AppNavigator from '../appNavigator';
+import { NAVIGATE } from '../actions/navigation';
+
+export default function (state, action) {
+  if (action.type === NAVIGATE) {
+    return AppNavigator.router.getStateForAction(
+      NavigationActions.navigate({
+        routeName: action.routeName,
+        params: action.params,
+      }), state);
+  }
+  return AppNavigator.router.getStateForAction(action, state);
+}

--- a/js/setup.js
+++ b/js/setup.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { Provider } from 'react-redux';
-
-import App from './app';
+import AppNavigatorWithHelpers from './app';
 import configureStore from './store/configureStore';
 
 function setup() : React.Component {
@@ -18,7 +17,7 @@ function setup() : React.Component {
     render() {
       return (
         <Provider store={this.state.store}>
-          <App />
+          <AppNavigatorWithHelpers />
         </Provider>
       );
     }


### PR DESCRIPTION
# [Integrate Redux in React Navigation](https://reactnavigation.org/docs/guides/redux)
Adds functionality to navigate between screens using Redux. This makes it possible to navigate to any screen from anywhere, and removes the need to pass down the `navigation` prop to children components.

When integrating Redux you have to keep track of the back button functionality yourself. An event listener has been added to the hardware back button for Android, using platform specific code.

_The old way of navigating without Redux is still supported._