### PR TITLE
Feature/navigate worker info

### DIFF
--- a/js/appNavigator.js
+++ b/js/appNavigator.js
@@ -46,12 +46,15 @@ const CreateJobTab = StackNavigator({
 });
 
 // TODO Replace sample badge count with real value.
-const MyJobTab = StackNavigator({
+const MyJobsTab = StackNavigator({
   MyJobsScreen: {
     screen: MyJobsScreen,
   },
   JobInfoScreen: {
     screen: JobInfoScreen,
+  },
+  WorkerInfoScreen: {
+    screen: WorkerInfoScreen,
   },
 }, {
   navigationOptions: {
@@ -155,7 +158,7 @@ const AppNavigator = TabNavigator({
     screen: CreateJobTab,
   },
   MyJobsTab: {
-    screen: MyJobTab,
+    screen: MyJobsTab,
   },
   MyProfileTab: {
     screen: MyProfileTab,

--- a/js/components/developer/choose-worker-screen/index.js
+++ b/js/components/developer/choose-worker-screen/index.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
 import { Form, Content, List } from 'native-base';
+import { connect } from 'react-redux';
+import { navigate } from '../../../actions/navigation';
 import WorkerListItem from './workerListItem';
 import I18n from '../../../i18n';
 
@@ -11,15 +13,21 @@ const REFERENCES = [
   { author: 'John Deo', rating: '2', price: '150 kr', icon: ICON },
 ];
 
-export default class ChooseWorkerScreen extends Component {
+class ChooseWorkerScreen extends Component {
   static navigationOptions = {
     title: I18n.t('screen_titles.choose_worker'),
   };
 
+  static propTypes = {
+    navigate: React.PropTypes.func.isRequired,
+  }
+
+  // TODO Navigate to WorkerInfoScreen and display the correct information for the selected worker
   renderRow = reference =>
     <WorkerListItem
       author={reference.author} rating={reference.rating}
       price={reference.price} icon={reference.icon}
+      goToWorkerProfile={() => this.props.navigate('WorkerInfoScreen')}
     />
 
   render() {
@@ -32,3 +40,13 @@ export default class ChooseWorkerScreen extends Component {
     );
   }
 }
+
+function bindAction(dispatch) {
+  return {
+    navigate: (routeName, params) => dispatch(navigate(routeName, params)),
+  };
+}
+
+const mapStateToProps = state => ({ navigation: state.navigation });
+
+export default connect(mapStateToProps, bindAction)(ChooseWorkerScreen);

--- a/js/components/developer/choose-worker-screen/workerListItem.js
+++ b/js/components/developer/choose-worker-screen/workerListItem.js
@@ -15,10 +15,12 @@ export default class WorkerListItem extends Component {
       React.PropTypes.number.isRequired,
       React.PropTypes.shape({ uri: React.PropTypes.string.isRequired }),
     ]).isRequired,
+    goToWorkerProfile: React.PropTypes.func,
   }
 
   static defaultProps = {
     rating: noRatingString,
+    goToWorkerProfile: undefined,
   }
 
   render() {
@@ -29,7 +31,7 @@ export default class WorkerListItem extends Component {
     }
 
     return (
-      <ListItem onPress={() => alert(this.props.author)}>
+      <ListItem onPress={this.props.goToWorkerProfile}>
         <Left>
           <Thumbnail
             style={StyleSheet.flatten(ChooseWorkerStyles.pictureStyle)} source={this.props.icon}


### PR DESCRIPTION
## Adds navigation to WorkerInfoScreen from ChooseWorkerScreen

Basic navigation to generic WorkerInfoScreen from ChooseWorkerScreen.

_The selected worker information is not displayed at the moment. This functionality will be introduced in a future pull request._