### PR TITLE
Replace React Native logo placeholders with unique avatar placeholders

### DIFF
--- a/js/components/developer/choose-worker-screen/index.js
+++ b/js/components/developer/choose-worker-screen/index.js
@@ -6,11 +6,10 @@ import WorkerListItem from './workerListItem';
 import I18n from '../../../i18n';
 
 // Temporary data. Will be handled in another way in the future.
-const ICON = { uri: 'https://facebook.github.io/react/img/logo_og.png' };
 const REFERENCES = [
-  { author: 'John Doe', price: '500 kr', icon: ICON },
-  { author: 'Jhon Doe', rating: '3', price: '350 kr', icon: ICON },
-  { author: 'John Deo', rating: '2', price: '150 kr', icon: ICON },
+  { author: 'Jake Weary', price: '500 kr' },
+  { author: 'Samuel Serif', rating: '3', price: '350 kr' },
+  { author: 'Ruby von Rails', rating: '2', price: '150 kr' },
 ];
 
 class ChooseWorkerScreen extends Component {
@@ -26,7 +25,7 @@ class ChooseWorkerScreen extends Component {
   renderRow = reference =>
     <WorkerListItem
       author={reference.author} rating={reference.rating}
-      price={reference.price} icon={reference.icon}
+      price={reference.price} icon={{ uri: `https://api.adorable.io/avatars/80/${reference.author}` }}
       goToWorkerProfile={() => this.props.navigate('WorkerProfileScreen')}
     />
 

--- a/js/components/developer/my-profile-screen/profileInfo.js
+++ b/js/components/developer/my-profile-screen/profileInfo.js
@@ -13,8 +13,6 @@ import { createJsonDataAttributes } from '../../../networking/json';
 import { requestGetUser, requestPatchUser } from '../../../actions/userProfile';
 import { requestSignOut } from '../../../actions/session';
 
-const LOGO_URL = 'https://facebook.github.io/react/img/logo_og.png';
-
 class ProfileInfo extends Component {
 
   static propTypes = {
@@ -97,7 +95,7 @@ class ProfileInfo extends Component {
             <View>
               <Thumbnail
                 style={StyleSheet.flatten(style.logo)}
-                source={{ uri: LOGO_URL }}
+                source={{ uri: `https://api.adorable.io/avatars/140/${this.props.attributes.email}` }}
               />
               <Text style={StyleSheet.flatten(style.nameText)}>
                 <Text>{this.props.attributes.first_name} {this.props.attributes.last_name}</Text>

--- a/js/components/developer/reference-screen/index.js
+++ b/js/components/developer/reference-screen/index.js
@@ -4,12 +4,11 @@ import ReferenceListItem from './referenceListItem';
 import I18n from '../../../i18n';
 
 // Temporary data. Will be handled in another way in the future.
-const ICON = { uri: 'https://facebook.github.io/react/img/logo_og.png' };
 const REFERENCES = [
-  { reference: 'Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor', author: 'Anna', icon: ICON, date: '2017-04-10', rating: '4' },
-  { reference: 'Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor', author: 'Eva', icon: ICON, date: '2017-04-12', rating: '5' },
-  { reference: 'Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor', author: 'Johan', icon: ICON, date: '2017-04-14', rating: '2' },
-  { reference: 'Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor', author: 'John', icon: ICON, date: '2017-04-13', rating: '3' },
+  { reference: 'Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor', author: 'Anna', date: '2017-04-10', rating: '4' },
+  { reference: 'Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor', author: 'Eva', date: '2017-04-12', rating: '5' },
+  { reference: 'Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor', author: 'Johan', date: '2017-04-14', rating: '2' },
+  { reference: 'Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor', author: 'John', date: '2017-04-13', rating: '3' },
 ];
 
 export default class ReferenceScreen extends Component {
@@ -21,7 +20,7 @@ export default class ReferenceScreen extends Component {
     <ReferenceListItem
       reference={reference.reference}
       author={reference.author}
-      icon={reference.icon}
+      icon={{ uri: `https://api.adorable.io/avatars/80/${reference.author}` }}
       date={reference.date}
       rating={reference.rating}
     />

--- a/js/components/developer/worker-info-screen/index.js
+++ b/js/components/developer/worker-info-screen/index.js
@@ -19,9 +19,7 @@ export default class WorkerInfoScreen extends Component {
           <Card>
             <CardItem bordered>
               <ProfileHeader
-                picture={{
-                  uri: 'https://facebook.github.io/react/img/logo_og.png',
-                }}
+                picture={{ uri: `https://api.adorable.io/avatars/140/${NAME}` }}
                 name={NAME}
                 priceTot={'500 kr'}
                 priceHr={'100 kr/h'}


### PR DESCRIPTION
### Replace React Native logo placeholders with unique avatar placeholders

Previously all avatars were displaying the same icon (the React Native logo). This pull request replaces the React Native logo with avatars from http://avatars.adorable.io/, which generates unique avatar placeholders from an input value (e.g. a name/email or similar to identify a user).

Note that these still are placeholders, but they are now unique, making it easier to see how screens in the application are connected, as the same icon can be displayed for the same user, in different views.

**Screenshot showing the new avatar placeholders:**
![image](https://cloud.githubusercontent.com/assets/8606831/25853203/4679d7a6-34cc-11e7-947c-d440054980c2.png)
