### PR TITLE
Update API base URL

### DIFF
--- a/js/networking/url.js
+++ b/js/networking/url.js
@@ -2,4 +2,4 @@
 This is the base URL used for all API calls
 */
 
-export default 'https://sandbox-api.justarrived.xyz';
+export default 'https://api-p2p.justarrived.xyz';

--- a/js/reducers/jobCreation.js
+++ b/js/reducers/jobCreation.js
@@ -12,7 +12,7 @@ const initialState = {
   job_date: '',
   job_end_date: '',
   language_id: 38, // TODO handle languages
-  category_id: 8212, // TODO handle categories
+  category_id: 8, // TODO handle categories
   hourly_pay_id: 1, // TODO handle hourly pay
   skills: [1], // TODO handle skills
   city: '',


### PR DESCRIPTION
## Update API base URL
Changes the API base URL to match the new API URL: https://api-p2p.justarrived.xyz

Also changes the default job category id in the `jobCreation` reducer, to an arbitrary id that exists in the new API.