### PR TITLE
Display localized dates using moment.js

### DIFF
--- a/js/components/common/preview-job-card/previewDateCardItem.js
+++ b/js/components/common/preview-job-card/previewDateCardItem.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Grid, Col, CardItem } from 'native-base';
+import moment from 'moment';
 import I18n from '../../../i18n';
 
 import TextWithStackedNote from '../../common/text-with-stacked-note/textWithStackedNote';
@@ -7,20 +8,26 @@ import TextWithStackedNote from '../../common/text-with-stacked-note/textWithSta
 const DATE_STRING = I18n.t('date_and_time.date');
 const TIME_STRING = I18n.t('date_and_time.time');
 
-// Card showing when the job should be started, in the job creation preview.
-const PreviewDateCardItem = ({ date, time }) =>
+/*
+ Card showing when the job should be started, in the job creation preview.
+
+ Displays localized date and time using moment.
+ - 'L' format is localized date, i.e. 'MM/DD/YYYY' for English locale.
+ - 'LT' format is localized time, i.e 'HH:mm' for English.
+*/
+const PreviewDateCardItem = ({ date }) =>
   <CardItem bordered>
     <Grid>
       <Col>
         <TextWithStackedNote
           note={DATE_STRING}
-          text={date}
+          text={moment(date).format('L')}
         />
       </Col>
       <Col>
         <TextWithStackedNote
           note={TIME_STRING}
-          text={time}
+          text={moment(date).format('LT')}
         />
       </Col>
     </Grid>
@@ -28,12 +35,10 @@ const PreviewDateCardItem = ({ date, time }) =>
 
 PreviewDateCardItem.propTypes = {
   date: React.PropTypes.string,
-  time: React.PropTypes.string,
 };
 
 PreviewDateCardItem.defaultProps = {
   date: 'missing',
-  time: 'missing',
 };
 
 export default PreviewDateCardItem;

--- a/js/components/common/preview-job-card/previewJobCard.js
+++ b/js/components/common/preview-job-card/previewJobCard.js
@@ -24,8 +24,7 @@ const PreviewJobCard = ({ jobJson, duration, cost, footerNode }) =>
       cost={cost}
     />
     <PreviewDateCardItem
-      date={jobJson.helperDate.date}
-      time={jobJson.helperDate.time}
+      date={jobJson.job_date}
     />
     <PreviewLocationCardItem
       street={jobJson.street}

--- a/js/components/developer/my-jobs-screen/myJobsTab.js
+++ b/js/components/developer/my-jobs-screen/myJobsTab.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { ListView } from 'react-native';
 import { Container, Content } from 'native-base';
+import moment from 'moment';
 import AvatarListItem from '../../common/avatar-list-item/avatarListItem';
 import ListSectionHeader from '../../common/list-section-header/listSectionHeader';
 import JASpinner from '../../common/ja-spinner/JASpinner';
@@ -52,7 +53,7 @@ class MyJobsTab extends Component {
   renderRow = job =>
     <AvatarListItem
       title={job.attributes.name}
-      note={job.attributes.street}
+      note={moment(job.attributes.job_date).calendar()}
       status={'Aktiv'}
       icon={getTaskIcon(job.attributes.name)}
       toNextScreen={() => this.selectJob(job)}

--- a/js/components/developer/reference-screen/index.js
+++ b/js/components/developer/reference-screen/index.js
@@ -1,14 +1,15 @@
 import React, { Component } from 'react';
 import { Container, Content, List } from 'native-base';
+import moment from 'moment';
 import ReferenceListItem from './referenceListItem';
 import I18n from '../../../i18n';
 
 // Temporary data. Will be handled in another way in the future.
 const REFERENCES = [
-  { reference: 'Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor', author: 'Anna', date: '2017-04-10', rating: '4' },
-  { reference: 'Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor', author: 'Eva', date: '2017-04-12', rating: '5' },
-  { reference: 'Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor', author: 'Johan', date: '2017-04-14', rating: '2' },
-  { reference: 'Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor', author: 'John', date: '2017-04-13', rating: '3' },
+  { reference: 'Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor', author: 'Anna', date: '2017-05-08', rating: '4' },
+  { reference: 'Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor', author: 'Eva', date: '2017-05-01', rating: '5' },
+  { reference: 'Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor', author: 'Johan', date: '2017-02-08', rating: '2' },
+  { reference: 'Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor Lorem ipsum dolor', author: 'John', date: '2015-07-13', rating: '3' },
 ];
 
 export default class ReferenceScreen extends Component {
@@ -21,7 +22,7 @@ export default class ReferenceScreen extends Component {
       reference={reference.reference}
       author={reference.author}
       icon={{ uri: `https://api.adorable.io/avatars/80/${reference.author}` }}
-      date={reference.date}
+      date={moment(reference.date).fromNow(true)}
       rating={reference.rating}
     />
 

--- a/js/reducers/ownedJobs.js
+++ b/js/reducers/ownedJobs.js
@@ -106,11 +106,9 @@ export default function (state = initialState, action) {
       };
     case JOB_O_SELECT: {
       // Select a specific job for inspection
-      const selectedJob = action.jobJson;
-      selectedJob.attributes.helperDate = parseDateInfo(selectedJob.attributes.job_date);
       return {
         ...state,
-        selectedJob,
+        selectedJob: action.jobJson,
       };
     }
     case SESSION_REMOVE:

--- a/js/reducers/ownedJobs.js
+++ b/js/reducers/ownedJobs.js
@@ -3,8 +3,6 @@ import { JOB_O_RECEIVE, JOBS_O_REQUEST,
   JOBS_O_RECEIVE, JOB_O_SELECT } from '../actions/ownedJobs';
 import { SESSION_REMOVE } from '../actions/session';
 
-import { parseDateInfo } from '../networking/json';
-
 const initialState = {
   assigned: [],
   unassigned: [],


### PR DESCRIPTION
## Display localized dates using moment.js

- Jobs in list of jobs in `MyJobsScreen` now show localized (calendar) dates instead of addresses.
- `JobPreviewScreen` shows localized date.
- `ReferenceScreen` shows localized durations between _now_ and creation times of the references.

**Screenshots:**
![my-jobs-ss](https://cloud.githubusercontent.com/assets/8606831/25989957/4853d372-36fe-11e7-9ab1-c4edc6dae5a3.png)
![job-details-ss](https://cloud.githubusercontent.com/assets/8606831/25989961/4c0c5534-36fe-11e7-9e54-9412b79ea516.png)
![references-ss](https://cloud.githubusercontent.com/assets/8606831/25989982/638b0ebc-36fe-11e7-8b22-a0dc5f61c169.png)
