### PR TITLE
Update i18n translations, mainly change "job" to "task"

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -2,7 +2,7 @@
   "common": {
     "or": "OR",
   },
-  "job": {
+  "task": {
     "task_details": "Task details",
     "applications": "Applications",
     "when_will_the_task_be_performed": "When will the task be performed?",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -3,28 +3,28 @@
     "or": "OR",
   },
   "job": {
-    "job_details": "Job details",
+    "task_details": "Task details",
     "applications": "Applications",
-    "when_will_the_job_be_performed": "When will the job be performed?",
-    "create_job": "Create job",
-    "create_job_button": "Create Job",
+    "when_will_the_task_be_performed": "When will the task be performed?",
+    "order_task": "Order task",
+    "order_task_button": "Order Task",
     "location": "Location",
-    "where_will_the_job_be_performed": "Where will the job be performed?",
+    "where_will_the_task_be_performed": "Where will the task be performed?",
     "approximate_duration": "What's the approximate duration?",
-    "job_duration": "Job duration",
+    "task_duration": "Task duration",
     "headings": {
       "current": "Current",
       "history": "History",
     },
     "rating": {
-      "how_did_the_worker_perform_the_job": "We hope you enjoyed your experience, please write what you think about the experience you had using People",
+      "how_did_the_worker_perform_the_task": "We hope you enjoyed your experience, please write what you think about the experience you had using People",
       "communication": "Communication",
-      "work_quality": "Quality of service",
+      "quality_of_service": "Quality of service",
       "punctuality": "Punctuality",
       "write_review_here": "Write here",
       "no_rating_yet": "No rating yet",
       "thank_you": "Thank you!",
-      "recommendation": "Write a recommendation",
+      "write_a_recommendation": "Write a recommendation",
       "unrated": "Unrated",
       "thank_you": "Thank you!"
     }
@@ -66,13 +66,13 @@
     }
   },
   "section_headings": {
-    "assigned_jobs": "Assigned, awaiting completion",
-    "archived_jobs": "Completed jobs",
-    "unassigned_jobs": "Unassigned jobs"
+    "assigned_tasks": "Assigned, awaiting completion",
+    "archived_tasks": "Completed tasks",
+    "unassigned_tasks": "Unassigned tasks"
   },
   "wizard": {
     "welcome_to_people": "Welcome To People!",
-    "welcome_to_people_description": "People by JustArrived is an initiative to connect newcomers with local people in the Swedish community"
+    "welcome_to_people_description": "People by Just Arrived is an initiative to connect newcomers with local people in the Swedish community"
   },
   "account": {
     "first_name": "First name",
@@ -83,24 +83,24 @@
     "phone_number": "Phone number",
     "email": "Email",
     "password": "Password",
-    "profile_info": "Profile info",
-    "payment_info": "Payment info",
+    "profile_tab": "Profile",
+    "payment_details_tab": "Payment Details",
     "references": "References"
   },
   "worker_profile": {
     "presentation": "Presentation",
     "language": "Language",
     "education": "Education",
-    "prev_work": "Previous Work"
+    "previous_work": "Previous Work"
   },
   "screen_titles": {
-    "choose_job_type": "Choose Job Type",
-    "create_job": "Create Job",
+    "choose_task_type": "Choose Task Type",
+    "order_task": "Order Task",
     "login": "Login",
     "create_account": "Create Account",
-    "job_preview": "Job Preview",
-    "my_jobs": "My Jobs",
-    "job_info": "Job Info",
+    "task_preview": "Task Preview",
+    "my_tasks": "My Tasks",
+    "task_info": "Task Info",
     "my_profile": "My Profile",
     "rate_worker": "Rate Worker",
     "choose_language": "Choose Language",
@@ -110,9 +110,9 @@
     "worker_profile": "Profile of {{name}}"
   },
   "navigation_tabs": {
-    "create_job": "Create Job",
-    "my_jobs": "My Jobs",
-    "my_profile": "My Profile",
+    "order_task": "Order Task",
+    "my_tasks": "My Tasks",
+    "my_profile": "Profile",
     "developer": "Developer"
   },
   "forgot_password": {

--- a/js/appNavigator.js
+++ b/js/appNavigator.js
@@ -34,8 +34,8 @@ const CreateJobTab = StackNavigator({
   },
 }, {
   navigationOptions: {
-    tabBarLabel: I18n.t('navigation_tabs.create_job'),
-    tabBarIcon: ({ tintColor }) => JATabIcon({ name: 'home', tintColor, count: 0 }),
+    tabBarLabel: I18n.t('navigation_tabs.order_task'),
+    tabBarIcon: ({ tintColor }) => JATabIcon({ name: 'add-circle', tintColor, count: 0 }),
   },
 });
 
@@ -52,7 +52,7 @@ const MyJobsTab = StackNavigator({
   },
 }, {
   navigationOptions: {
-    tabBarLabel: I18n.t('navigation_tabs.my_jobs'),
+    tabBarLabel: I18n.t('navigation_tabs.my_tasks'),
     tabBarIcon: ({ tintColor }) => JATabIcon({ name: 'briefcase', tintColor, count: 5 }),
   },
 });

--- a/js/components/common/preview-job-card/previewDurationAndCostCardItem.js
+++ b/js/components/common/preview-job-card/previewDurationAndCostCardItem.js
@@ -7,7 +7,7 @@ const PreviewDurationAndCostCardItem = ({ duration, cost }) =>
   <CardItem bordered>
     <Grid>
       <Row>
-        <Text note>{I18n.t('job.job_duration')}</Text>
+        <Text note>{I18n.t('job.task_duration')}</Text>
       </Row>
       <Row>
         <Body>

--- a/js/components/common/preview-job-card/previewDurationAndCostCardItem.js
+++ b/js/components/common/preview-job-card/previewDurationAndCostCardItem.js
@@ -7,7 +7,7 @@ const PreviewDurationAndCostCardItem = ({ duration, cost }) =>
   <CardItem bordered>
     <Grid>
       <Row>
-        <Text note>{I18n.t('job.task_duration')}</Text>
+        <Text note>{I18n.t('task.task_duration')}</Text>
       </Row>
       <Row>
         <Body>

--- a/js/components/developer/choose-worker-screen/workerListItem.js
+++ b/js/components/developer/choose-worker-screen/workerListItem.js
@@ -4,7 +4,7 @@ import { Text, Thumbnail, Body, Row, Left, ListItem, Icon, Right } from 'native-
 import ChooseWorkerStyles from './chooseWorkerStyles';
 import I18n from '../../../i18n';
 
-const noRatingString = I18n.t('job.rating.no_rating_yet');
+const noRatingString = I18n.t('task.rating.no_rating_yet');
 
 export default class WorkerListItem extends Component {
   static propTypes = {

--- a/js/components/developer/create-job-screen/calendarCard.js
+++ b/js/components/developer/create-job-screen/calendarCard.js
@@ -23,7 +23,7 @@ class CalendarCard extends Component {
       <Card>
         <CardHeader
           icon="calendar" title={I18n.t('date_and_time.date')}
-          subtitle={I18n.t('job.when_will_the_task_be_performed')}
+          subtitle={I18n.t('task.when_will_the_task_be_performed')}
         />
         <Form >
           <Grid>

--- a/js/components/developer/create-job-screen/calendarCard.js
+++ b/js/components/developer/create-job-screen/calendarCard.js
@@ -23,7 +23,7 @@ class CalendarCard extends Component {
       <Card>
         <CardHeader
           icon="calendar" title={I18n.t('date_and_time.date')}
-          subtitle={I18n.t('job.when_will_the_job_be_performed')}
+          subtitle={I18n.t('job.when_will_the_task_be_performed')}
         />
         <Form >
           <Grid>

--- a/js/components/developer/create-job-screen/index.js
+++ b/js/components/developer/create-job-screen/index.js
@@ -10,7 +10,7 @@ import I18n from '../../../i18n';
 export default class CreateJobScreen extends Component {
 
   static navigationOptions = {
-    title: I18n.t('job.order_task'),
+    title: I18n.t('task.order_task'),
   };
 
   goToJobPreview = () => (

--- a/js/components/developer/create-job-screen/index.js
+++ b/js/components/developer/create-job-screen/index.js
@@ -10,7 +10,7 @@ import I18n from '../../../i18n';
 export default class CreateJobScreen extends Component {
 
   static navigationOptions = {
-    title: I18n.t('job.create_job'),
+    title: I18n.t('job.order_task'),
   };
 
   goToJobPreview = () => (

--- a/js/components/developer/create-job-screen/placeCard.js
+++ b/js/components/developer/create-job-screen/placeCard.js
@@ -17,8 +17,8 @@ class PlaceCard extends Component {
     return (
       <Card>
         <CardHeader
-          icon="pin" title={I18n.t('job.location')}
-          subtitle={I18n.t('job.where_will_the_task_be_performed')}
+          icon="pin" title={I18n.t('task.location')}
+          subtitle={I18n.t('task.where_will_the_task_be_performed')}
         />
         <Form>
           <Item floatingLabel>

--- a/js/components/developer/create-job-screen/placeCard.js
+++ b/js/components/developer/create-job-screen/placeCard.js
@@ -18,7 +18,7 @@ class PlaceCard extends Component {
       <Card>
         <CardHeader
           icon="pin" title={I18n.t('job.location')}
-          subtitle={I18n.t('job.where_will_the_job_be_performed')}
+          subtitle={I18n.t('job.where_will_the_task_be_performed')}
         />
         <Form>
           <Item floatingLabel>

--- a/js/components/developer/create-job-screen/timeCard.js
+++ b/js/components/developer/create-job-screen/timeCard.js
@@ -36,7 +36,7 @@ const TimeCard = ({ hours, setJobHours }) => {
   });
   return (
     <Card>
-      <CardHeader icon="time" title={I18n.t('date_and_time.time')} subtitle={I18n.t('job.approximate_duration')} />
+      <CardHeader icon="time" title={I18n.t('date_and_time.time')} subtitle={I18n.t('task.approximate_duration')} />
       {radioButtons}
       <CardItem footer />
     </Card>

--- a/js/components/developer/job-information-screen/index.js
+++ b/js/components/developer/job-information-screen/index.js
@@ -17,12 +17,12 @@ class JobInformationScreen extends Component {
     return (
       <Container>
         <Tabs>
-          <Tab heading={I18n.t('job.task_details')} >
+          <Tab heading={I18n.t('task.task_details')} >
             <JobDetails
               jobJson={this.props.jobJson}
             />
           </Tab>
-          <Tab heading={I18n.t('job.applications')}>
+          <Tab heading={I18n.t('task.applications')}>
             <ChooseWorkerScreen />
           </Tab>
         </Tabs>

--- a/js/components/developer/job-information-screen/index.js
+++ b/js/components/developer/job-information-screen/index.js
@@ -7,7 +7,7 @@ import I18n from '../../../i18n';
 
 class JobInformationScreen extends Component {
   static navigationOptions = {
-    title: I18n.t('screen_titles.my_jobs'),
+    title: I18n.t('screen_titles.my_tasks'),
   };
   static propTypes = {
     jobJson: React.PropTypes.objectOf(React.PropTypes.any).isRequired,
@@ -17,7 +17,7 @@ class JobInformationScreen extends Component {
     return (
       <Container>
         <Tabs>
-          <Tab heading={I18n.t('job.job_details')} >
+          <Tab heading={I18n.t('job.task_details')} >
             <JobDetails
               jobJson={this.props.jobJson}
             />

--- a/js/components/developer/job-preview-screen/index.js
+++ b/js/components/developer/job-preview-screen/index.js
@@ -40,7 +40,7 @@ class JobPreviewScreen extends Component {
   getPreviewFooter() {
     return (
       <CardItemButton
-        text={I18n.t('job.order_task_button')}
+        text={I18n.t('task.order_task_button')}
         onPress={() => this.postJob()}
       />
     );

--- a/js/components/developer/job-preview-screen/index.js
+++ b/js/components/developer/job-preview-screen/index.js
@@ -15,7 +15,7 @@ import { requestPostJob } from '../../../actions/jobs';
 class JobPreviewScreen extends Component {
 
   static navigationOptions = {
-    title: I18n.t('screen_titles.job_preview'),
+    title: I18n.t('screen_titles.task_preview'),
   };
 
   static propTypes = {
@@ -40,7 +40,7 @@ class JobPreviewScreen extends Component {
   getPreviewFooter() {
     return (
       <CardItemButton
-        text={I18n.t('job.create_job_button')}
+        text={I18n.t('job.order_task_button')}
         onPress={() => this.postJob()}
       />
     );

--- a/js/components/developer/my-jobs-screen/index.js
+++ b/js/components/developer/my-jobs-screen/index.js
@@ -44,14 +44,14 @@ class MyJobsScreen extends Component {
     };
     return (
       <Tabs>
-        <Tab heading={I18n.t('job.headings.current')}>
+        <Tab heading={I18n.t('task.headings.current')}>
           <MyJobsTab
             onRefresh={() => this.downloadJobs()}
             data={temporaryActive}
             toNextScreen={() => this.navigateToNextScreen()}
           />
         </Tab>
-        <Tab heading={I18n.t('job.headings.history')}>
+        <Tab heading={I18n.t('task.headings.history')}>
           <MyJobsTab
             onRefresh={() => this.downloadJobs()}
             data={temporaryArchived}

--- a/js/components/developer/my-jobs-screen/index.js
+++ b/js/components/developer/my-jobs-screen/index.js
@@ -8,7 +8,7 @@ import { requestGetUserJobs } from '../../../actions/ownedJobs';
 
 class MyJobsScreen extends Component {
   static navigationOptions = {
-    title: I18n.t('screen_titles.my_jobs'),
+    title: I18n.t('screen_titles.my_tasks'),
   };
 
   static propTypes = {
@@ -35,12 +35,12 @@ class MyJobsScreen extends Component {
 
   render() {
     const temporaryActive = {
-      'section_headings.assigned_jobs': this.props.jobsAssigned,
-      'section_headings.unassigned_jobs': this.props.jobsUnassigned,
+      'section_headings.assigned_tasks': this.props.jobsAssigned,
+      'section_headings.unassigned_tasks': this.props.jobsUnassigned,
     };
 
     const temporaryArchived = {
-      'section_headings.archived_jobs': this.props.jobsHistoric,
+      'section_headings.archived_tasks': this.props.jobsHistoric,
     };
     return (
       <Tabs>

--- a/js/components/developer/my-profile-screen/index.js
+++ b/js/components/developer/my-profile-screen/index.js
@@ -13,10 +13,10 @@ export default class MyProfileScreen extends Component {
     return (
       <Container>
         <Tabs>
-          <Tab heading={I18n.t('account.profile_info')}>
+          <Tab heading={I18n.t('account.profile_tab')}>
             <ProfileInfo />
           </Tab>
-          <Tab heading={I18n.t('account.payment_info')}>
+          <Tab heading={I18n.t('account.payment_details_tab')}>
             <PaymentInfoScreen />
           </Tab>
         </Tabs>

--- a/js/components/developer/rate-work-screen/index.js
+++ b/js/components/developer/rate-work-screen/index.js
@@ -28,7 +28,7 @@ export default class RateWorkScreen extends Component {
             >{I18n.t('job.rating.thank_you')}</Text>
             <Text
               style={RatingScreenStyles.bodyText}
-            >{I18n.t('job.rating.how_did_the_worker_perform_the_job')}</Text>
+            >{I18n.t('job.rating.how_did_the_worker_perform_the_task')}</Text>
             <Text
               style={RatingScreenStyles.ratingText}
             >{I18n.t('job.rating.punctuality')}</Text>
@@ -39,11 +39,11 @@ export default class RateWorkScreen extends Component {
             <RatingBar />
             <Text
               style={RatingScreenStyles.ratingText}
-            >{I18n.t('job.rating.work_quality')}</Text>
+            >{I18n.t('job.rating.quality_of_service')}</Text>
             <RatingBar />
             <Text
               style={RatingScreenStyles.ratingText}
-            >{I18n.t('job.rating.recommendation')}</Text>
+            >{I18n.t('job.rating.write_a_recommendation')}</Text>
           </View>
           <View style={RatingScreenStyles.textBox}>
             <RecommendationTextbox placeholder={I18n.t('job.rating.write_review_here')} />

--- a/js/components/developer/rate-work-screen/index.js
+++ b/js/components/developer/rate-work-screen/index.js
@@ -25,28 +25,28 @@ export default class RateWorkScreen extends Component {
             <JALogo />
             <Text
               style={RatingScreenStyles.headerText}
-            >{I18n.t('job.rating.thank_you')}</Text>
+            >{I18n.t('task.rating.thank_you')}</Text>
             <Text
               style={RatingScreenStyles.bodyText}
-            >{I18n.t('job.rating.how_did_the_worker_perform_the_task')}</Text>
+            >{I18n.t('task.rating.how_did_the_worker_perform_the_task')}</Text>
             <Text
               style={RatingScreenStyles.ratingText}
-            >{I18n.t('job.rating.punctuality')}</Text>
+            >{I18n.t('task.rating.punctuality')}</Text>
             <RatingBar />
             <Text
               style={RatingScreenStyles.ratingText}
-            >{I18n.t('job.rating.communication')}</Text>
+            >{I18n.t('task.rating.communication')}</Text>
             <RatingBar />
             <Text
               style={RatingScreenStyles.ratingText}
-            >{I18n.t('job.rating.quality_of_service')}</Text>
+            >{I18n.t('task.rating.quality_of_service')}</Text>
             <RatingBar />
             <Text
               style={RatingScreenStyles.ratingText}
-            >{I18n.t('job.rating.write_a_recommendation')}</Text>
+            >{I18n.t('task.rating.write_a_recommendation')}</Text>
           </View>
           <View style={RatingScreenStyles.textBox}>
-            <RecommendationTextbox placeholder={I18n.t('job.rating.write_review_here')} />
+            <RecommendationTextbox placeholder={I18n.t('task.rating.write_review_here')} />
           </View>
           <View style={StyleSheet.flatten(RatingScreenStyles.buttonStyle)}>
             {/* TODO add actionOnClick functionality*/}

--- a/js/components/developer/worker-info-screen/index.js
+++ b/js/components/developer/worker-info-screen/index.js
@@ -47,7 +47,7 @@ export default class WorkerInfoScreen extends Component {
               </CardItem>
               <CardItem bordered>
                 <TextWithStackedNote
-                  note={I18n.t('worker_profile.prev_work')}
+                  note={I18n.t('worker_profile.previous_work')}
                   text={'Banktjänsteman'}
                 />
               </CardItem>

--- a/js/components/developer/worker-info-screen/profileHeader.js
+++ b/js/components/developer/worker-info-screen/profileHeader.js
@@ -5,7 +5,7 @@ import WorkerInfoStyles from './workerInfoStyles';
 import { imageProp } from '../../../resources/propTypes';
 import I18n from '../../../i18n';
 
-const noRatingString = I18n.t('job.rating.unrated');
+const noRatingString = I18n.t('task.rating.unrated');
 
 export default class ProfileHeader extends Component {
 

--- a/js/components/developer/worker-profile-screen/index.js
+++ b/js/components/developer/worker-profile-screen/index.js
@@ -17,7 +17,7 @@ export default class WorkerProfileScreen extends Component {
     return (
       <Container>
         <Tabs>
-          <Tab heading={I18n.t('account.profile_info')} >
+          <Tab heading={I18n.t('account.profile_tab')} >
             <WorkerInfoScreen />
           </Tab>
           <Tab heading={I18n.t('account.references')}>


### PR DESCRIPTION
## Update i18n translations, mainly change "job" to "task"
Changes translations in `en.json`. Mainly occurrences of "job" are changed to "task".
Various other translations were also updated, for a more consistent style.