### PR TITLE
Create payment modal for payments

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -1,6 +1,6 @@
 {
   "common": {
-    "or": "OR",
+    "or": "OR"
   },
   "task": {
     "task_details": "Task details",
@@ -14,7 +14,7 @@
     "task_duration": "Task duration",
     "headings": {
       "current": "Current",
-      "history": "History",
+      "history": "History"
     },
     "rating": {
       "how_did_the_worker_perform_the_task": "We hope you enjoyed your experience, please write what you think about the experience you had using People",
@@ -25,8 +25,7 @@
       "no_rating_yet": "No rating yet",
       "thank_you": "Thank you!",
       "write_a_recommendation": "Write a recommendation",
-      "unrated": "Unrated",
-      "thank_you": "Thank you!"
+      "unrated": "Unrated"
     }
   }, "confirmation": {
         "the_task_is_completed": "The task is completed!",
@@ -34,7 +33,7 @@
         "invite_a_friend": "Invite a friend to the app and get 15% of on youre next service",
         "invite_with_sms": "Invite with SMS",
         "invite_with_facebook": "Invite with Facebook",
-        "skip_invite": "Skip invite",
+        "skip_invite": "Skip invite"
   },
   "categories": {
     "shoveling": {
@@ -124,7 +123,7 @@
   },
   "forgot_password": {
     "forgot_your_password": "Forgot your password?",
-    "forgot_your_password_info": "No worries! Type your email address in the box below and then check your inbox",
+    "forgot_your_password_info": "No worries! Type your email address in the box below and then check your inbox"
   },
   "login": {
     "sign_in_button": "Log in to your account",
@@ -139,7 +138,7 @@
     "accept_pul_and_terms": "I accept the PUL and Terms of Use"
   },
   "sign_out": {
-    "sign_out_button": "Sign out",
+    "sign_out_button": "Sign out"
   },
   "date_and_time": {
     "date": "Date",
@@ -154,7 +153,7 @@
     "save": "Save",
     "cancel": "Cancel",
     "next": "Next",
-    "skip": "Skip",
+    "skip": "Skip"
   },
   "card": {
     "card_holder": "Card holder",
@@ -168,10 +167,15 @@
       "visa": "Visa"
     }
   },
+  "payment": {
+    "confirm_payment": "Confirm Payment",
+    "credit_card": "With credit card {{card_number}}.",
+    "pay_button": "Pay ({{amount}})"
+  },
   "language": {
     "select_display_language": "Select app display language"
   },
   "social": {
     "facebook": "Log in with Facebook"
-  },
+  }
 }

--- a/js/components/common/ja-input/index.js
+++ b/js/components/common/ja-input/index.js
@@ -88,6 +88,14 @@ export default class JAInput extends Component {
         keyboardTypeUsed = 'email-address';
         break;
 
+      case JA_INPUT.CVC:
+        placeholderTitle = 'CVC';
+        icon = <JAInputIcon name="key" />;
+        secureInput = true;
+        keyboardTypeUsed = 'numeric';
+        numberOfCharactersPermitted = 3;
+        break;
+
       default:
         /* Gives an input with no placeholderTitle or icon and default values for
         secureInput, keyboardType, and numberOfCharactersPermitted */

--- a/js/components/developer/payment-info-screen/index.js
+++ b/js/components/developer/payment-info-screen/index.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import style from './paymentInfoStyle';
 import AvatarListItem from '../../common/avatar-list-item/avatarListItem';
 import I18n from '../../../i18n';
+import PaymentModal from './paymentModal';
 
 class PaymentInfoScreen extends Component {
   static navigationOptions = {
@@ -16,11 +17,41 @@ class PaymentInfoScreen extends Component {
     creditCards: PropTypes.objectOf(PropTypes.any).isRequired,
   };
 
-  renderRow = card => <AvatarListItem title={card.cardNumber} note={card.brand} icon={card.icon} />
+  constructor(props) {
+    super(props);
+    this.state = {
+      modalVisible: false,
+      selectedCard: null, // TODO Handle selected card state using Redux
+      amount: '300 SEK',  // TODO Replace with real amount
+    };
+  }
+
+  setModalVisible(visible) {
+    this.setState({ modalVisible: visible });
+  }
+
+  selectCard(card) {
+    this.setState({ selectedCard: card });
+    this.setModalVisible(true);
+  }
+
+  renderRow = card =>
+    <AvatarListItem
+      title={card.cardNumber}
+      note={card.brand}
+      icon={card.icon}
+      toNextScreen={() => this.selectCard(card)}
+    />
 
   render() {
     return (
       <Content>
+        <PaymentModal
+          visible={this.state.modalVisible}
+          setModalVisible={visible => this.setModalVisible(visible)}
+          onRequestClose={() => this.setModalVisible(false)}
+          data={{ creditCard: this.state.selectedCard, amount: this.state.amount }}
+        />
         <List dataArray={this.props.creditCards.data} renderRow={this.renderRow} />
         <View style={style.addCardButton}>
           <Button block>

--- a/js/components/developer/payment-info-screen/paymentInfoStyle.js
+++ b/js/components/developer/payment-info-screen/paymentInfoStyle.js
@@ -1,8 +1,30 @@
 import { StyleSheet } from 'react-native';
+import { PAYMENT_MODAL_BACKGROUND_OVERLAY } from '../../../resources/colors';
 
 const style = StyleSheet.create({
   addCardButton: {
     padding: 10,
+  },
+  cancelPaymentButton: {
+    marginTop: 10,
+  },
+  modalContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: PAYMENT_MODAL_BACKGROUND_OVERLAY,
+  },
+  noFlex: {
+    flex: 0,
+  },
+  modalTextContainer: {
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+  },
+  modalRowContainer: {
+    paddingTop: 0,
+    flexDirection: 'column',
+    alignItems: 'center',
   },
 });
 

--- a/js/components/developer/payment-info-screen/paymentModal.js
+++ b/js/components/developer/payment-info-screen/paymentModal.js
@@ -53,7 +53,7 @@ export default class PaymentModal extends Component {
                 style={StyleSheet.flatten(style.cancelPaymentButton)}
                 onPress={() => setModalVisible(false)}
               >
-                <Text>Cancel</Text>
+                <Text>{I18n.t('button_actions.cancel')}</Text>
               </Button>
             </CardItem>
           </Card>

--- a/js/components/developer/payment-info-screen/paymentModal.js
+++ b/js/components/developer/payment-info-screen/paymentModal.js
@@ -1,0 +1,64 @@
+import React, { Component, PropTypes } from 'react';
+import { Modal, View, StyleSheet } from 'react-native';
+import { Text, Button, Card, CardItem } from 'native-base';
+import style from './paymentInfoStyle';
+import I18n from '../../../i18n';
+import JAInput from '../../common/ja-input';
+import { JA_INPUT } from '../../../resources/constants';
+
+// TODO Implement payment functionality
+export default class PaymentModal extends Component {
+
+  static propTypes = {
+    visible: PropTypes.bool.isRequired,
+    onRequestClose: PropTypes.func.isRequired,
+    setModalVisible: PropTypes.func.isRequired,
+    data: PropTypes.shape({
+      creditCard: PropTypes.objectOf(PropTypes.any),
+      amount: PropTypes.string,
+    }).isRequired,
+  };
+
+  render() {
+    if (!this.props.visible) {
+      return null;
+    }
+
+    const { visible, onRequestClose, setModalVisible, data } = this.props;
+
+    return (
+      <Modal
+        animationType={'fade'}
+        transparent
+        visible={visible}
+        onRequestClose={() => onRequestClose()}
+      >
+        <View style={style.modalContainer}>
+          <Card style={StyleSheet.flatten(style.noFlex)}>
+            <CardItem bordered style={StyleSheet.flatten(style.modalTextContainer)}>
+              <Text>{I18n.t('payment.confirm_payment')}</Text>
+              <Text note>
+                {I18n.t('payment.credit_card', { card_number: data.creditCard.cardNumber })}
+              </Text>
+            </CardItem>
+            <CardItem style={StyleSheet.flatten(style.modalRowContainer)}>
+              <JAInput typeOfInput={JA_INPUT.CVC} />
+            </CardItem>
+            <CardItem style={StyleSheet.flatten(style.modalRowContainer)}>
+              <Button block onPress={() => setModalVisible(false)}>
+                <Text>{I18n.t('payment.pay_button', { amount: data.amount })}</Text>
+              </Button>
+              <Button
+                block small light
+                style={StyleSheet.flatten(style.cancelPaymentButton)}
+                onPress={() => setModalVisible(false)}
+              >
+                <Text>Cancel</Text>
+              </Button>
+            </CardItem>
+          </Card>
+        </View>
+      </Modal>
+    );
+  }
+}

--- a/js/resources/colors.js
+++ b/js/resources/colors.js
@@ -27,3 +27,4 @@ export const ICON = '#757575';
 
 // Misc
 export const CARD_IMAGE_HEADER_SHADOW = 'rgba(0, 0, 0, 0.75)';
+export const PAYMENT_MODAL_BACKGROUND_OVERLAY = 'rgba(0, 0, 0, 0.5)';

--- a/js/resources/constants.js
+++ b/js/resources/constants.js
@@ -18,4 +18,5 @@ export const JA_INPUT = {
   PHONE_NUMBER: 'PHONE_NUMBER',
   EMAIL: 'EMAIL',
   PASSWORD: 'PASSWORD',
+  CVC: 'CVC',
 };


### PR DESCRIPTION
## Create payment modal for payments
Displays a payment modal upon clicking a credit card in the list of credit cards in `PaymentInfoScreen`.
_Payment functionality is however not implemented yet._

**Screenshot showing the payment modal:**
![paymentmodal](https://cloud.githubusercontent.com/assets/8606831/26723968/5262626c-4797-11e7-8e65-9aaeb3c0b22c.png)
